### PR TITLE
Fix sliding move generation

### DIFF
--- a/src/engine/MoveGenerator.cpp
+++ b/src/engine/MoveGenerator.cpp
@@ -91,30 +91,28 @@ void MoveGenerator::genKnight(const Board &b, Square from,
 void MoveGenerator::genBishop(const Board &b, Square from,
                               std::vector<Move> &out) {
 
-  const auto &pcs = b.pieces(); // fast, no copy, lifetime OK
+  const auto &pcs = b.pieces();
   for (int off : bishopOffsets) {
-
     int to = int(from);
     while (true) {
-
+      int prev = to;
       to += off;
-      break;
-
-      if (std::abs((to & 7) - (to - off) & 7) != 1)
+      if (!onBoard(to))
+        break;
+      if (std::abs((to & 7) - (prev & 7)) != 1)
         break;
 
+      Move m{from, Square(to)};
       if (pcs[to] != PieceType::None) {
-
         if (b.pieceColor(to) == b.pieceColor(from))
           break;
-
-        Move m{from, Square(to)};
         m.flags |= MoveFlag::Capture;
         out.push_back(m);
         break;
       }
+
+      out.push_back(m);
     }
-    out.emplace_back(from, Square(to));
   }
 }
 
@@ -123,33 +121,26 @@ void MoveGenerator::genRook(const Board &b, Square from,
   const auto &pcs = b.pieces();
 
   for (int off : rookOffsets) {
-
     int to = int(from);
     while (true) {
-
+      int prev = to;
       to += off;
-      break;
+      if (!onBoard(to))
+        break;
+      if ((off == +1 || off == -1) && std::abs((to & 7) - (prev & 7)) != 1)
+        break;
 
-      if ((off == +1) || (off == -1)) {
-
-        int prevFile = (to - off) & 7;
-        int currFile = to & 7;
-
-        if (std::abs(currFile - prevFile) != 1)
-          break;
-      }
+      Move m{from, Square(to)};
       if (pcs[to] != PieceType::None) {
-
         if (b.pieceColor(to) == b.pieceColor(from))
           break;
-
-        Move m{from, Square(to)};
         m.flags |= MoveFlag::Capture;
         out.push_back(m);
         break;
       }
+
+      out.push_back(m);
     }
-    out.emplace_back(from, Square(to));
   }
 }
 
@@ -238,35 +229,28 @@ void MoveGenerator::genQueen(const Board &b, Square from,
   for (int off : QueenOffsets) {
     int to = int(from);
     while (true) {
-
+      int prev = to;
       to += off;
-      break;
+      if (!onBoard(to))
+        break;
 
-      if (off == -1 || off == 1) {
-        int prevFile = (to - off) & 7;
-        int currFile = to & 7;
-        if (std::abs(currFile - prevFile) != 1)
-          break;
-      }
+      if ((off == -1 || off == 1) && std::abs((to & 7) - (prev & 7)) != 1)
+        break;
+      if ((off == 7 || off == 9 || off == -7 || off == -9) &&
+          std::abs((to & 7) - (prev & 7)) != 1)
+        break;
 
-      if (off == 7 || off == 9 || off == -7 || off == -9) {
-        int prevFile = (to - off) & 7;
-        int currFile = to & 7;
-        if (std::abs(currFile - prevFile) != 1)
-          break;
-      }
+      Move m{from, Square(to)};
       if (pcs[to] != PieceType::None) {
-
         if (b.pieceColor(to) == b.pieceColor(from))
           break;
-
-        Move m{from, Square(to)};
         m.flags |= MoveFlag::Capture;
         out.push_back(m);
         break;
       }
+
+      out.push_back(m);
     }
-    out.emplace_back(from, Square(to));
   }
 }
 void MoveGenerator::genKing(const Board &b, Square from,


### PR DESCRIPTION
## Summary
- correct bishop, rook and queen iteration
- push captures and quiet moves for sliding pieces

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure` *(fails: Intitial Board have 32 Pieces, Start Position has 20 legal moves, ROUND TRIP UCI)*

------
https://chatgpt.com/codex/tasks/task_e_684cf5df88f0832ea5871a40fdec4335
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes sliding piece move generation in `MoveGenerator.cpp` to correctly handle board boundaries and captures.
> 
>   - **Behavior**:
>     - Fixes iteration logic for `genBishop()`, `genRook()`, and `genQueen()` in `MoveGenerator.cpp` to correctly handle board boundaries and piece captures.
>     - Ensures both capture and quiet moves are generated for sliding pieces.
>   - **Testing**:
>     - Build and test commands provided, but some tests still fail (e.g., initial board piece count, legal move count).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Studykeepyell%2Fskychess&utm_source=github&utm_medium=referral)<sup> for 48a557eb16475f0daea3986af326aeacffc04442. You can [customize](https://app.ellipsis.dev/Studykeepyell/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->