### PR TITLE
Implement square placement in Renderer

### DIFF
--- a/src/gui/Renderer.cpp
+++ b/src/gui/Renderer.cpp
@@ -23,6 +23,8 @@ void Renderer::draw(sf::RenderWindow &win, const Board &board) {
       sf::RectangleShape &sq = isLight ? light_ : dark_;
 
       // place (0,0) at bottom-left like a real board
+      sq.setPosition(f * tile_, (7 - r) * tile_);
+      win.draw(sq);
     }
   }
 


### PR DESCRIPTION
## Summary
- draw board squares by placing them with `(0,0)` at bottom left

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_684f12513704832eae9343318185df47
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Place board squares with origin at bottom-left in `Renderer::draw` for realistic board representation.
> 
>   - **Behavior**:
>     - In `Renderer::draw`, board squares are now placed with `(0,0)` at the bottom-left, aligning with real board conventions.
>     - Uses `sq.setPosition(f * tile_, (7 - r) * tile_)` to position squares.
>   - **Testing**:
>     - Build and test using `cmake` and `ctest` commands as specified.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Studykeepyell%2Fskychess&utm_source=github&utm_medium=referral)<sup> for 17e4030641c67eba5c5cfbe39b075005a36dd104. You can [customize](https://app.ellipsis.dev/Studykeepyell/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->