### PR TITLE
Fix SFML 3 event usage

### DIFF
--- a/src/engine/Controller.cpp
+++ b/src/engine/Controller.cpp
@@ -8,19 +8,29 @@ Controller::Controller()
 
 void Controller::run() {
   while (window_.isOpen()) {
-    // SFML 3.x: pollEvent() returns std::optional<sf::Event>
+    // In SFML 3, pollEvent returns a std::optional<sf::Event>
     while (auto optEvent = window_.pollEvent()) {
-      auto &event = *optEvent; // unwrap the optional
+      const sf::Event &event = *optEvent; // unwrap the optional
 
-      if (event.type == sf::Event::Closed) {
+      if (event.is<sf::Event::Closed>()) {
         window_.close();
-      } else if (event.type == sf::Event::MouseButtonPressed &&
-                 event.mouseButton.button == sf::Mouse::Button::Left) {
-        handleClick(event.mouseButton.x, event.mouseButton.y);
+      } else if (const auto *mouse = event.getIf<sf::Event::MouseButtonPressed>()) {
+        if (mouse->button == sf::Mouse::Button::Left)
+          handleClick(mouse->position.x, mouse->position.y);
       }
     }
     window_.clear();
     render_.draw(window_, board_, legalMoves_, selected_);
     window_.display();
   }
+}
+
+void Controller::handleClick(int x, int y) {
+  int file = x / static_cast<int>(tileSize);
+  int rank = 7 - y / static_cast<int>(tileSize);
+  if (file < 0 || file >= 8 || rank < 0 || rank >= 8)
+    return;
+
+  selected_ = Square(rank * 8 + file);
+  legalMoves_ = board_.legalMoves();
 }


### PR DESCRIPTION
## Summary
- adapt `Controller` to SFML 3 event API
- add minimal `handleClick` implementation

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68670187f150832e919dd94cc6a55ca2
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adapt `Controller` to SFML 3 event API and add minimal `handleClick` implementation in `Controller.cpp`.
> 
>   - **Event Handling**:
>     - Update `Controller::run()` in `Controller.cpp` to use SFML 3 event API.
>     - Change `pollEvent()` to return `std::optional<sf::Event>` and use `event.is<sf::Event::Closed>()` and `event.getIf<sf::Event::MouseButtonPressed>()`.
>   - **Functionality**:
>     - Add `Controller::handleClick(int x, int y)` to process mouse clicks, calculating board position and updating `selected_` and `legalMoves_`.
>   - **Misc**:
>     - Minor comment updates in `Controller.cpp` to reflect SFML 3 changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Studykeepyell%2Fskychess&utm_source=github&utm_medium=referral)<sup> for 44751a2e70176031dbfc4372cd1c0c2660936f2b. You can [customize](https://app.ellipsis.dev/Studykeepyell/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->